### PR TITLE
Async signing keys

### DIFF
--- a/examples/graph_discovery.rs
+++ b/examples/graph_discovery.rs
@@ -25,3 +25,23 @@ fn tenant_discovery() {
         .oauth()
         .unwrap();
 }
+
+// Using async
+#[allow(dead_code)]
+async fn async_keys_discovery() {
+    let signing_keys: MicrosoftSigningKeysV1 =
+        GraphDiscovery::V1.async_signing_keys().await.unwrap();
+    println!("{:#?}", signing_keys);
+
+    let signing_keys2: MicrosoftSigningKeysV2 =
+        GraphDiscovery::V2.async_signing_keys().await.unwrap();
+    println!("{:#?}", signing_keys2);
+}
+
+#[allow(dead_code)]
+async fn async_tenant_discovery() {
+    let _oauth: OAuth = GraphDiscovery::Tenant("<YOUR_TENANT_ID>".into())
+        .async_oauth()
+        .await
+        .unwrap();
+}

--- a/graph-oauth/src/discovery/graphdiscovery.rs
+++ b/graph-oauth/src/discovery/graphdiscovery.rs
@@ -58,6 +58,15 @@ pub enum GraphDiscovery {
 }
 
 impl GraphDiscovery {
+    /// Get the URL for the public keys used by the Microsoft identity platform
+    /// to sign security tokens.
+    ///
+    /// # Example
+    /// ```
+    /// # use graph_oauth::oauth::graphdiscovery::GraphDiscovery;
+    /// let url = GraphDiscovery::V1.url();
+    /// println!("{}", url);
+    /// ```
     pub fn url(&self) -> String {
         match self {
             GraphDiscovery::V1 => format!("{}/{}", LOGIN_LIVE_HOST, OPEN_ID_PATH),
@@ -68,6 +77,15 @@ impl GraphDiscovery {
         }
     }
 
+    /// Get the public keys used by the Microsoft identity platform
+    /// to sign security tokens.
+    ///
+    /// # Example
+    /// ```
+    /// # use graph_oauth::oauth::graphdiscovery::GraphDiscovery;
+    /// let keys: serde_json::Value = GraphDiscovery::V1.signing_keys().unwrap();
+    /// println!("{:#?}", keys);
+    /// ```
     pub fn signing_keys<T>(self) -> Result<T, OAuthError>
     where
         for<'de> T: serde::Deserialize<'de>,
@@ -76,6 +94,15 @@ impl GraphDiscovery {
         Ok(t)
     }
 
+    /// Get the public keys used by the Microsoft identity platform
+    /// to sign security tokens.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// # use graph_oauth::oauth::graphdiscovery::GraphDiscovery;
+    /// let keys: serde_json::Value = GraphDiscovery::V1.async_signing_keys().await.unwrap();
+    /// println!("{:#?}", keys);
+    /// ```
     pub async fn async_signing_keys<T>(self) -> Result<T, OAuthError>
     where
         for<'de> T: serde::Deserialize<'de>,
@@ -84,6 +111,16 @@ impl GraphDiscovery {
         Ok(t)
     }
 
+    /// Automatically convert the public keys used by the Microsoft identity platform
+    /// to sign security tokens into an OAuth object. This will get the common urls
+    /// for authorization and access tokens and insert them into OAuth.
+    ///
+    /// # Example
+    /// ```
+    /// # use graph_oauth::oauth::graphdiscovery::GraphDiscovery;
+    /// let oauth = GraphDiscovery::V1.oauth().unwrap();
+    /// println!("{:#?}", oauth);
+    /// ```
     pub fn oauth(self) -> Result<OAuth, OAuthError> {
         let mut oauth = OAuth::new();
         match self {
@@ -108,6 +145,16 @@ impl GraphDiscovery {
         }
     }
 
+    /// Automatically convert the public keys used by the Microsoft identity platform
+    /// to sign security tokens into an OAuth object. This will get the common urls
+    /// for authorization and access tokens and insert them into OAuth.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// # use graph_oauth::oauth::graphdiscovery::GraphDiscovery;
+    /// let oauth = GraphDiscovery::V1.async_oauth().await.unwrap();
+    /// println!("{:#?}", oauth);
+    /// ```
     pub async fn async_oauth(self) -> Result<OAuth, OAuthError> {
         let mut oauth = OAuth::new();
         match self {

--- a/graph-oauth/src/discovery/mod.rs
+++ b/graph-oauth/src/discovery/mod.rs
@@ -1,4 +1,3 @@
 pub mod graphdiscovery;
 pub mod jwtkeys;
 pub mod wellknown;
-pub use from_as::*;

--- a/graph-oauth/src/discovery/wellknown.rs
+++ b/graph-oauth/src/discovery/wellknown.rs
@@ -1,38 +1,26 @@
-use graph_error::GraphFailure;
+use graph_error::GraphResult;
 
 #[derive(Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct WellKnown;
 
 impl WellKnown {
-    pub fn signing_keys<T>(url: &str) -> Result<T, GraphFailure>
+    pub fn signing_keys<T>(url: &str) -> GraphResult<T>
     where
         for<'de> T: serde::Deserialize<'de>,
     {
-        let client = reqwest::blocking::Client::builder().build()?;
-        let response = client.get(url).send();
-
-        match response {
-            Ok(t) => {
-                let keys: T = t.json()?;
-                Ok(keys)
-            },
-            Err(e) => Err(GraphFailure::from(e)),
-        }
+        let client = reqwest::blocking::Client::new();
+        let response = client.get(url).send()?;
+        let keys: T = response.json()?;
+        Ok(keys)
     }
 
-    pub async fn async_signing_keys<T>(url: &str) -> Result<T, GraphFailure>
+    pub async fn async_signing_keys<T>(url: &str) -> GraphResult<T>
     where
         for<'de> T: serde::Deserialize<'de>,
     {
         let client = reqwest::Client::new();
-        let response = client.get(url).send().await;
-
-        match response {
-            Ok(t) => {
-                let keys: T = t.json().await?;
-                Ok(keys)
-            },
-            Err(e) => Err(GraphFailure::from(e)),
-        }
+        let response = client.get(url).send().await?;
+        let keys: T = response.json().await?;
+        Ok(keys)
     }
 }

--- a/tests/discovery_tests.rs
+++ b/tests/discovery_tests.rs
@@ -1,53 +1,13 @@
-use from_as::*;
-use graph_oauth::oauth::wellknown::{Commons, WellKnown};
+use graph_oauth::oauth::jwtkeys::JWTKeys;
 use graph_oauth::oauth::{OAuth, OAuthCredential};
 use graph_rs::oauth::graphdiscovery::{
     GraphDiscovery, MicrosoftSigningKeysV1, MicrosoftSigningKeysV2,
 };
 
 #[test]
-fn signing_keys() {
-    let v1_keys: MicrosoftSigningKeysV1 = GraphDiscovery::V1.signing_keys().unwrap();
-    v1_keys
-        .as_file("./test_files/well_known_discovery/graphv1.json")
-        .unwrap();
-    let v2_keys: MicrosoftSigningKeysV2 = GraphDiscovery::V2.signing_keys().unwrap();
-    v2_keys
-        .as_file("./test_files/well_known_discovery/graphv2.json")
-        .unwrap();
-    signing_keys_v1();
-    signing_keys_v2();
-    graph_discovery_oauth_v1();
-    graph_discovery_oauth_v2();
-}
-
-fn signing_keys_v1() {
-    let t: MicrosoftSigningKeysV1 =
-        Commons::signing_keys("https://login.live.com/.well-known/openid-configuration").unwrap();
-
-    let u: MicrosoftSigningKeysV1 =
-        MicrosoftSigningKeysV1::from_file("./test_files/well_known_discovery/graphv1.json")
-            .unwrap();
-    assert_eq!(t, u);
-}
-
-fn signing_keys_v2() {
-    let t: MicrosoftSigningKeysV2 = Commons::signing_keys(
-        "https://login.microsoftonline.com/common/.well-known/openid-configuration",
-    )
-    .unwrap();
-
-    let u: MicrosoftSigningKeysV2 =
-        MicrosoftSigningKeysV2::from_file("./test_files/well_known_discovery/graphv2.json")
-            .unwrap();
-    assert_eq!(t, u);
-}
-
 fn graph_discovery_oauth_v1() {
     let oauth: OAuth = GraphDiscovery::V1.oauth().unwrap();
-    let keys: MicrosoftSigningKeysV1 =
-        MicrosoftSigningKeysV1::from_file("./test_files/well_known_discovery/graphv1.json")
-            .unwrap();
+    let keys: MicrosoftSigningKeysV1 = GraphDiscovery::V1.signing_keys().unwrap();
     assert_eq!(
         oauth.get(OAuthCredential::AuthorizeURL),
         Some(keys.authorization_endpoint.to_string())
@@ -66,11 +26,10 @@ fn graph_discovery_oauth_v1() {
     );
 }
 
+#[test]
 fn graph_discovery_oauth_v2() {
     let oauth: OAuth = GraphDiscovery::V2.oauth().unwrap();
-    let keys: MicrosoftSigningKeysV2 =
-        MicrosoftSigningKeysV2::from_file("./test_files/well_known_discovery/graphv2.json")
-            .unwrap();
+    let keys: MicrosoftSigningKeysV2 = GraphDiscovery::V2.signing_keys().unwrap();
     assert_eq!(
         oauth.get(OAuthCredential::AuthorizeURL),
         Some(keys.authorization_endpoint.to_string())
@@ -87,4 +46,46 @@ fn graph_discovery_oauth_v2() {
         oauth.get(OAuthCredential::LogoutURL),
         Some(keys.end_session_endpoint.to_string())
     );
+}
+
+#[tokio::test]
+async fn async_graph_discovery_oauth_v2() {
+    let oauth: OAuth = GraphDiscovery::V2.async_oauth().await.unwrap();
+    let keys: MicrosoftSigningKeysV2 = GraphDiscovery::V2.async_signing_keys().await.unwrap();
+    assert_eq!(
+        oauth.get(OAuthCredential::AuthorizeURL),
+        Some(keys.authorization_endpoint.to_string())
+    );
+    assert_eq!(
+        oauth.get(OAuthCredential::AccessTokenURL),
+        Some(keys.token_endpoint.to_string())
+    );
+    assert_eq!(
+        oauth.get(OAuthCredential::RefreshTokenURL),
+        Some(keys.token_endpoint.to_string())
+    );
+    assert_eq!(
+        oauth.get(OAuthCredential::LogoutURL),
+        Some(keys.end_session_endpoint.to_string())
+    );
+}
+
+#[test]
+fn jwt_keys() {
+    let keys = JWTKeys::discovery().unwrap();
+    assert!(keys.keys().len() > 0);
+
+    for key in keys.into_iter() {
+        assert!(key.kty.is_some());
+    }
+}
+
+#[tokio::test]
+async fn async_jwt_keys() {
+    let keys = JWTKeys::async_discovery().await.unwrap();
+    assert!(keys.keys().len() > 0);
+
+    for key in keys.into_iter() {
+        assert!(key.kty.is_some());
+    }
 }


### PR DESCRIPTION
Adds async methods for Microsoft signing keys. You can get the OAuth object by calling

- `GraphDiscovery::V1.async_oauth()`
- `GraphDiscovery::V2.async_oauth()`
- `GraphDiscovery::Tenant("TENANT").async_oauth()`

and the signing keys by calling

- `GraphDiscovery::V1.async_signing_keys()`
- `GraphDiscovery::V2.async_signing_keys()`
- `GraphDiscovery::Tenant("TENANT").async_signing_keys()`