### PR TITLE
Allow reports to be downloaded as strings

### DIFF
--- a/src/client/api_macros/register_download.rs
+++ b/src/client/api_macros/register_download.rs
@@ -1,11 +1,10 @@
 #[macro_use]
 macro_rules! register_download {
     ( { name: $name:ident, response: $T:ty, path: $template:expr, params: 0 } ) => {
-      pub fn $name<P: AsRef<Path>>(&'a self, directory: P) -> $T {
+      pub fn $name(&'a self) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -19,11 +18,10 @@ macro_rules! register_download {
     };
 
     ( { name: $name:ident, response: $T:ty, path: $template:expr, params: 1 } ) => {
-      pub fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, id: S, directory: P) -> $T {
+      pub fn $name<S: AsRef<str>>(&'a self, id: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -37,11 +35,10 @@ macro_rules! register_download {
     };
 
     ( { name: $name:ident, response: $T:ty, path: $template:expr } ) => {
-      pub fn $name<P: AsRef<Path>>(&'a self, directory: P) -> $T {
+      pub fn $name(&'a self) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -56,11 +53,10 @@ macro_rules! register_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, has_body: false} ) => {
       #[doc = $doc]
-      pub fn $name<P: AsRef<Path>>(&'a self, directory: P) -> $T {
+      pub fn $name(&'a self) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -74,11 +70,10 @@ macro_rules! register_download {
     };
 
     ( { name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ] } ) => {
-      pub fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, $p: S, directory: P) -> $T {
+      pub fn $name<S: AsRef<str>>(&'a self, $p: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -93,11 +88,10 @@ macro_rules! register_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ] } ) => {
       #[doc = $doc]
-      pub fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, $p: S, directory: P) -> $T {
+      pub fn $name<S: AsRef<str>>(&'a self, $p: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -112,11 +106,10 @@ macro_rules! register_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ], has_body: false } ) => {
       #[doc = $doc]
-      pub fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, $p: S, directory: P) -> $T {
+      pub fn $name<S: AsRef<str>>(&'a self, $p: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -131,11 +124,10 @@ macro_rules! register_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ], has_body: true } ) => {
       #[doc = $doc]
-      pub fn $name<S: AsRef<str>, P: AsRef<Path>, B: serde::Serialize>(&'a self, $p: S, directory: P, body: &B) -> $T {
+      pub fn $name<S: AsRef<str>, B: serde::Serialize>(&'a self, $p: S, body: &B) -> $T {
           let client = self.client.request();
           client.set_request(vec![
               graph_http::RequestAttribute::Method(Method::GET),
-              graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
               graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
           ]).unwrap();
 
@@ -156,11 +148,10 @@ macro_rules! register_download {
 #[macro_use]
 macro_rules! register_async_download {
     ( { name: $name:ident, response: $T:ty, path: $template:expr, params: 0 } ) => {
-      pub async fn $name<P: AsRef<Path>>(&'a self, directory: P) -> $T {
+      pub async fn $name(&'a self) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -174,11 +165,10 @@ macro_rules! register_async_download {
     };
 
     ( { name: $name:ident, response: $T:ty, path: $template:expr, params: 1 } ) => {
-      pub async fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, id: S, directory: P) -> $T {
+      pub async fn $name<S: AsRef<str>>(&'a self, id: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -192,11 +182,10 @@ macro_rules! register_async_download {
     };
 
     ( { name: $name:ident, response: $T:ty, path: $template:expr } ) => {
-      pub async fn $name<P: AsRef<Path>>(&'a self, directory: P) -> $T {
+      pub async fn $name(&'a self) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -211,11 +200,10 @@ macro_rules! register_async_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, has_body: false } ) => {
       #[doc = $doc]
-      pub async fn $name<P: AsRef<Path>>(&'a self, directory: P) -> $T {
+      pub async fn $name(&'a self) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -229,11 +217,10 @@ macro_rules! register_async_download {
     };
 
     ( { name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ] } ) => {
-      pub async fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, $p: S, directory: P) -> $T {
+      pub async fn $name<S: AsRef<str>>(&'a self, $p: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -248,11 +235,10 @@ macro_rules! register_async_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ] } ) => {
       #[doc = $doc]
-      pub async fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, $p: S, directory: P) -> $T {
+      pub async fn $name<S: AsRef<str>>(&'a self, $p: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -267,11 +253,10 @@ macro_rules! register_async_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ], has_body: false } ) => {
       #[doc = $doc]
-      pub async fn $name<S: AsRef<str>, P: AsRef<Path>>(&'a self, $p: S, directory: P) -> $T {
+      pub async fn $name<S: AsRef<str>>(&'a self, $p: S) -> $T {
         self.client.request()
             .set_request(vec![
                 graph_http::RequestAttribute::Method(Method::GET),
-                graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
                 graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
             ]).unwrap();
 
@@ -286,11 +271,10 @@ macro_rules! register_async_download {
 
     ( { doc: $doc:expr, name: $name:ident, response: $T:ty, path: $template:expr, params: [ $p:ident ], has_body: true } ) => {
       #[doc = $doc]
-      pub async fn $name<S: AsRef<str>, P: AsRef<Path>, B: serde::Serialize>(&'a self, $p: S, directory: P, body: &B) -> $T {
+      pub async fn $name<S: AsRef<str>, B: serde::Serialize>(&'a self, $p: S, body: &B) -> $T {
           let client = self.client.request();
           client.set_request(vec![
               graph_http::RequestAttribute::Method(Method::GET),
-              graph_http::RequestAttribute::Download(directory.as_ref().to_path_buf()),
               graph_http::RequestAttribute::RequestType(graph_http::RequestType::Redirect),
           ]).unwrap();
 

--- a/src/drive/manual_request.rs
+++ b/src/drive/manual_request.rs
@@ -180,7 +180,9 @@ impl<'a> DrivesRequest<'a, BlockingHttpClient> {
                 RequestAttribute::RequestType(RequestType::Redirect),
             ])
             .unwrap();
-        self.client.request().download()
+        let download_client = self.client.request().download();
+        download_client.set_dir(directory.as_ref().to_path_buf());
+        download_client
     }
 }
 
@@ -199,6 +201,10 @@ impl<'a> DrivesRequest<'a, AsyncHttpClient> {
                 RequestAttribute::RequestType(RequestType::Redirect),
             ])
             .unwrap();
-        futures::executor::block_on(self.client.request().download())
+        futures::executor::block_on(async {
+            let download_client = self.client.request().download().await;
+            download_client.set_dir(directory.as_ref().to_path_buf()).await;
+            download_client
+        })
     }
 }

--- a/tests/onenote_request.rs
+++ b/tests/onenote_request.rs
@@ -163,9 +163,11 @@ fn download_page() {
                 .user(&id)
                 .onenote()
                 .page(page_id)
-                .download_page("./test_files");
+                .download_page();
+
 
             download_page.rename(OsString::from("downloaded_page.html"));
+            download_page.set_dir("./test_files");
             let result = download_page.send();
 
             if let Err(e) = result {

--- a/tests/reports_request.rs
+++ b/tests/reports_request.rs
@@ -23,10 +23,10 @@ fn download_office_365_user_counts_reports_test() {
         let download_client = client
             .v1()
             .reports()
-            .get_office_365_active_user_counts("D90", "./test_files");
+            .get_office_365_active_user_counts("D90");
 
         download_client.rename(OsString::from("user_count_report.csv"));
-
+        download_client.set_dir("./test_files");
         let path_buf = download_client.send().expect(
             "Request Error. API: Reports | Method: download get_office_365_active_user_counts.",
         );
@@ -40,7 +40,7 @@ async fn async_download_office_365_user_counts_reports_test() {
     let _lock = THROTTLE_MUTEX.lock().unwrap();
 
     if let Some((_id, client)) =
-        OAuthTestClient::graph_by_rid_async(ResourceIdentity::Reports).await
+    OAuthTestClient::graph_by_rid_async(ResourceIdentity::Reports).await
     {
         let file_location = "./test_files/async_user_count_report.csv";
         let mut clean_up = AsyncCleanUp::new_remove_existing(file_location);
@@ -49,11 +49,14 @@ async fn async_download_office_365_user_counts_reports_test() {
         let download_client = client
             .v1()
             .reports()
-            .get_office_365_active_user_counts("D90", "./test_files")
+            .get_office_365_active_user_counts("D90")
             .await;
 
         download_client
             .rename(OsString::from("async_user_count_report.csv"))
+            .await;
+        download_client
+            .set_dir("./test_files")
             .await;
 
         let path_buf = download_client.send()


### PR DESCRIPTION
I've made a few changes to the download reports API, to allow the user to download the report either into a file or as a string.

The only breaking change is in the download_page() method of OnenoteRequest.

My use cases for this change : 

In a file
![image](https://user-images.githubusercontent.com/2280811/144273390-cc831f50-e3e6-4481-a11a-f3e35410e857.png)

As a string
![image](https://user-images.githubusercontent.com/2280811/144275301-fe53cf67-4385-4c77-99f7-f0bc6cd1980e.png)
