### PR TITLE
Add cast query param

### DIFF
--- a/graph-http/src/intoresponse.rs
+++ b/graph-http/src/intoresponse.rs
@@ -146,6 +146,13 @@ where
         self
     }
 
+    pub fn cast(self, value: &str) -> Self {
+        self.client.url_mut(|url| {
+            url.cast(value);
+        });
+        self
+    }
+
     pub fn header<H: IntoHeaderName>(self, name: H, value: HeaderValue) -> Self {
         self.client.header(name, value);
         self

--- a/graph-http/src/url/graphurl.rs
+++ b/graph-http/src/url/graphurl.rs
@@ -160,6 +160,10 @@ impl GraphUrl {
     pub fn top(&mut self, value: &str) {
         self.append_query_pair("$top", value.as_ref());
     }
+
+    pub fn cast(&mut self, value: &str) {
+        self.extend_path(&[value]);
+    }
 }
 
 impl From<Url> for GraphUrl {


### PR DESCRIPTION
Related : https://github.com/sreeise/graph-rs/issues/325


Example of usage :
``` rust
let deleted_groups = client
        .v1()
        .directory()
        .list_deleted_items()
        .cast("microsoft.graph.group")
        .select(&["id"])
        .text()
        .await?;
```
Usage cast() multiple times on the same request result on an error because we extend the inner Url each time.
I tried to save the cast in the GraphUrl struct and only update the inner Url just before when we need to but that imply a lot of changes elsewhere.
