### PR TITLE
Graph failure sync hot fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-rs-sdk"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["sreeise"]
 edition = "2018"
 readme = "README.md"
@@ -42,9 +42,9 @@ rayon = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 
-graph-oauth = { path = "./graph-oauth", version = "0.1.1" }
-graph-http = { path = "./graph-http", version = "0.1.2" }
-graph-error = { path = "./graph-error", version = "0.1.1" }
+graph-oauth = { path = "./graph-oauth", version = "0.1.2" }
+graph-http = { path = "./graph-http", version = "0.1.3" }
+graph-error = { path = "./graph-error", version = "0.1.2" }
 graph-core = { path = "./graph-core", version = "0.1.1" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Now available on stable Rust at [crates.io](https://crates.io/crates/graph-rs-sdk)
 
-    graph-rs-sdk = "0.1.0"
+    graph-rs-sdk = "0.1.3"
 
 0.1.0 and above use stable Rust. Anything before 0.1.0 uses nightly Rust.
 
@@ -111,7 +111,7 @@ pub struct DriveItem {
     // ... Any other fields
 }
         
-let response: DriveItem = client.v1()
+let response: GraphResponse<DriveItem> = client.v1()
     .me()
     .drive()
     .get_items("ITEM_ID")

--- a/examples/onenote_pages.rs
+++ b/examples/onenote_pages.rs
@@ -1,4 +1,3 @@
-use graph_http::GraphResponse;
 use graph_rs_sdk::prelude::*;
 use std::ffi::OsString;
 use std::str::FromStr;
@@ -18,7 +17,10 @@ static DOWNLOAD_PATH: &str = "DOWNLOAD_PATH";
 // Include the file extension such as .html
 static FILE_NAME: &str = "FILE_NAME";
 
-fn main() {}
+fn main() {
+    get_page_html_content();
+    download_page_as_html();
+}
 
 fn get_page_html_content() {
     let client = Graph::new(ACCESS_TOKEN);

--- a/graph-codegen/src/api_types/request_metadata.rs
+++ b/graph-codegen/src/api_types/request_metadata.rs
@@ -206,6 +206,7 @@ impl PathMetadata {
         self.path = self.path.trim_start_matches(path_start).to_string();
     }
 
+    #[allow(unused_assignments)]
     pub fn operation_id_start(&mut self, pat: &str) {
         let mut to = String::new();
         if pat.contains('.') {

--- a/graph-codegen/src/openapi/operation.rs
+++ b/graph-codegen/src/openapi/operation.rs
@@ -138,6 +138,7 @@ impl Operation {
         self.request_body.is_some()
     }
 
+    #[allow(unused_assignments)]
     pub fn request_metadata(&self, http_method: HttpMethod) -> RequestMetadata {
         let operation_mapping = self.operation_id.operation_mapping();
         let mut parent = String::new();

--- a/graph-codegen/src/traits/request.rs
+++ b/graph-codegen/src/traits/request.rs
@@ -138,6 +138,7 @@ impl RequestParser for &str {
         op_mapping
     }
 
+    #[allow(unused_assignments)]
     fn transform_path(&self) -> String {
         let mut path = self.to_string();
         let path_clone = path.clone();

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-error"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["sreeise"]
 edition = "2018"
 license = "MIT"

--- a/graph-error/src/error.rs
+++ b/graph-error/src/error.rs
@@ -270,8 +270,8 @@ impl WithGraphError for reqwest::blocking::Response {
             let headers = Some(GraphHeaders::from(&self));
             let error_message = self.json().unwrap_or_default();
             Err(GraphError {
-                code,
                 headers,
+                code,
                 error_message,
             })
         } else {
@@ -292,8 +292,8 @@ impl WithGraphErrorAsync for reqwest::Response {
             let headers = Some(GraphHeaders::from(&self));
             let error_message = self.json().await.unwrap_or_default();
             Err(GraphError {
-                code,
                 headers,
+                code,
                 error_message,
             })
         } else {

--- a/graph-error/src/graph_failure.rs
+++ b/graph-error/src/graph_failure.rs
@@ -1,7 +1,5 @@
-use crate::download::{AsyncDownloadError, BlockingDownloadError};
 use crate::error::GraphError;
 use crate::internal::GraphRsError;
-use crate::ioerror::{AsyncIoError, ThreadedIoError};
 use std::cell::BorrowMutError;
 use std::io::ErrorKind;
 use std::str::Utf8Error;
@@ -70,18 +68,6 @@ pub enum GraphFailure {
 
     #[error("Crypto Error (Unknown)")]
     CryptoError,
-
-    #[error("Blocking download error:\n{0:#?}")]
-    BlockingDownloadError(#[from] BlockingDownloadError),
-
-    #[error("Async download error:\n{0:#?}")]
-    AsyncDownloadError(#[from] AsyncDownloadError),
-
-    #[error("Async Io error:\n{0:#?}")]
-    AsyncIoError(#[from] AsyncIoError),
-
-    #[error("Threaded Io error:\n{0:#?}")]
-    ThreadedIoError(#[from] ThreadedIoError),
 }
 
 impl GraphFailure {

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-http"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["sreeise"]
 edition = "2018"
 license = "MIT"

--- a/graph-http/src/dispatch.rs
+++ b/graph-http/src/dispatch.rs
@@ -91,7 +91,7 @@ where
             return Err(self.error.unwrap_or_default());
         }
         let response = self.request.send()?;
-        Ok(std::convert::TryFrom::try_from(response)?)
+        std::convert::TryFrom::try_from(response)
     }
 }
 

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-oauth"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["sreeise"]
 edition = "2018"
 license = "MIT"

--- a/graph-oauth/src/accesstoken.rs
+++ b/graph-oauth/src/accesstoken.rs
@@ -299,11 +299,8 @@ impl AccessToken {
     /// let mut access_token = AccessToken::default();
     /// println!("{:#?}", access_token.refresh_token());
     /// ```
-    pub fn refresh_token(self) -> Option<String> {
-        match self.refresh_token {
-            Some(t) => Some(t),
-            None => None,
-        }
+    pub fn refresh_token(&self) -> Option<String> {
+        self.refresh_token.clone()
     }
 
     /// Get the id token.

--- a/tests/graph_error.rs
+++ b/tests/graph_error.rs
@@ -33,7 +33,6 @@ fn test_graph_failure(err: GraphFailure, expect: GraphError) {
         GraphFailure::HandlebarsTemplateRenderError(e) => {
             panic!("Expected GraphFailure::GraphError, got {}", e)
         }
-        _ => {}
     }
 }
 

--- a/tests/reports_request.rs
+++ b/tests/reports_request.rs
@@ -1,5 +1,4 @@
 use graph_core::resource::ResourceIdentity;
-use graph_rs_sdk::prelude::*;
 use std::ffi::OsString;
 use std::path::Path;
 use test_tools::common::TestTools;


### PR DESCRIPTION
Addresses #328 and does some clean up.

0.1.3 will be the new version once these fixes go in.