### PR TITLE
fix team creation response

### DIFF
--- a/src/teams/request.rs
+++ b/src/teams/request.rs
@@ -76,7 +76,7 @@ where
     post!({
         doc: "# Add new entity to teams",
         name: create_team,
-        response: serde_json::Value,
+        response: NoContent,
         path: "/teams",
         params: 0,
         has_body: true


### PR DESCRIPTION
Just the fix you proposed.
Since the response of graph for team creation has no content, that's what it should be in the code too.