### PR TITLE
Use a feature flag to choose the TLS implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ async-trait = "0.1"
 base64 = "0.13"
 futures = "0.3"
 handlebars = "2.0.2" # TODO: Update to 4
-reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/sreeise/graph-rs"
 description = "Microsoft Graph Api Client"
+rust-version = "1.60"
 
 exclude = [
     "test_files/*",
@@ -34,7 +35,7 @@ async-trait = "0.1"
 base64 = "0.13"
 futures = "0.3"
 handlebars = "2.0.2" # TODO: Update to 4
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream","multipart"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "gzip", "blocking", "stream","multipart"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -48,6 +49,11 @@ graph-oauth = { path = "./graph-oauth", version = "0.2.0" }
 graph-http = { path = "./graph-http", version = "0.2.2" }
 graph-error = { path = "./graph-error", version = "0.1.2" }
 graph-core = { path = "./graph-core", version = "0.3.0" }
+
+[features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 from_as = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 base64 = "0.13"
 futures = "0.3"
 handlebars = "2.0.2" # TODO: Update to 4
-reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 base64 = "0.13"
 futures = "0.3"
 handlebars = "2.0.2" # TODO: Update to 4
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream","multipart"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/sreeise/graph-rs"
 description = "Microsoft Graph Api Client"
-rust-version = "1.60"
 
 exclude = [
     "test_files/*",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ config but in general most of them are implemented.
 
 The client supports both blocking and async requests.
 
+### Cargo Feature Flags
+
+- `native-tls`: Use the `native-tls` TLS backend (OpenSSL on *nix, SChannel on Windows, Secure Transport on macOS). 
+- `rustls-tls`: Use the `rustls-tls` TLS backend (cross-platform backend, only supports TLS 1.2 and 1.3).
+
+Default features: `default=["native-tls"]`
+
 ### Blocking Client
 
 To use the blocking client

--- a/graph-codegen/Cargo.toml
+++ b/graph-codegen/Cargo.toml
@@ -15,7 +15,7 @@ Inflector = "0.11.4"
 lazy_static = "1.4.0"
 rayon = "1.5.0"
 regex = "1"
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "gzip", "blocking", "stream"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/graph-codegen/Cargo.toml
+++ b/graph-codegen/Cargo.toml
@@ -15,7 +15,7 @@ Inflector = "0.11.4"
 lazy_static = "1.4.0"
 rayon = "1.5.0"
 regex = "1"
-reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/graph-codegen/Cargo.toml
+++ b/graph-codegen/Cargo.toml
@@ -15,7 +15,7 @@ Inflector = "0.11.4"
 lazy_static = "1.4.0"
 rayon = "1.5.0"
 regex = "1"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 handlebars = "2.0.2"
 http-serde = "1"
 hyper = "0.14"
-reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
 ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 handlebars = "2.0.2"
 http-serde = "1"
 hyper = "0.14"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
 ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/graph-error/Cargo.toml
+++ b/graph-error/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 handlebars = "2.0.2"
 http-serde = "1"
 hyper = "0.14"
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "gzip", "blocking", "stream"] }
 ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -18,7 +18,7 @@ futures-util = "0.3"
 handlebars = "2.0.2"
 parking_lot = "0.12.0"
 percent-encoding = "2"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "multipart"] }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream", "multipart", "rustls-tls", "gzip"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -18,7 +18,8 @@ futures-util = "0.3"
 handlebars = "2.0.2"
 parking_lot = "0.12.0"
 percent-encoding = "2"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "multipart", "rustls-tls", "gzip"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8"

--- a/graph-http/Cargo.toml
+++ b/graph-http/Cargo.toml
@@ -18,7 +18,7 @@ futures-util = "0.3"
 handlebars = "2.0.2"
 parking_lot = "0.12.0"
 percent-encoding = "2"
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "gzip", "blocking", "stream"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.13"
 chrono = { version = "0.4.6", features = ["serde"] }
 chrono-humanize = "0.0.11"
 from_as = "0.1"
-reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "gzip", "blocking", "stream"] }
 
 ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.13"
 chrono = { version = "0.4.6", features = ["serde"] }
 chrono-humanize = "0.0.11"
 from_as = "0.1"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
 ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }
 serde-aux = "2"

--- a/graph-oauth/Cargo.toml
+++ b/graph-oauth/Cargo.toml
@@ -16,7 +16,8 @@ base64 = "0.13"
 chrono = { version = "0.4.6", features = ["serde"] }
 chrono-humanize = "0.0.11"
 from_as = "0.1"
-reqwest = { version = "0.11", features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls", "gzip", "blocking", "stream"] }
+
 ring = "0.16.15"
 serde = { version = "1", features = ["derive"] }
 serde-aux = "2"


### PR DESCRIPTION
Fixes #395

The following features have been added:
- `default-tls` : use the platform's default TLS backend
- `rustls-tls` : use the `rustls` crate (TLS 1.2, TLS 1.3) for environments that don't support `default-tls`

The default feature set is `default = ["native-tls"]` to ensure backwards compatibility.

Apologies for the # of commits, I don't think I can squash commits on my end